### PR TITLE
Use 4k Flash with Emulation to save Settings on Robin E3D

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D.h
@@ -203,3 +203,9 @@
 #ifndef ST7920_DELAY_3
   #define ST7920_DELAY_3           DELAY_NS(125)
 #endif
+
+#define FLASH_EEPROM_EMULATION
+#define EEPROM_PAGE_SIZE     (0x800U) // 2KB
+#define EEPROM_START_ADDRESS (0x8000000UL + (STM32_FLASH_SIZE) * 1024UL - (EEPROM_PAGE_SIZE) * 2UL)
+#undef E2END
+#define E2END                (EEPROM_PAGE_SIZE - 1) // 2KB

--- a/buildroot/share/PlatformIO/ldscripts/mks_robin_e3.ld
+++ b/buildroot/share/PlatformIO/ldscripts/mks_robin_e3.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K - 40
-  rom (rx)  : ORIGIN = 0x08005000, LENGTH = 256K - 20K
+  rom (rx)  : ORIGIN = 0x08005000, LENGTH = 256K - 20K - 4K
 }
 
 /* Provide memory region aliases for common.inc */


### PR DESCRIPTION
Strip 4k from rom for EEPROM Emulation to save settings with M500

### Description

Robin E3D can't save settings at all

### Benefits

Save Settings to Flash